### PR TITLE
Spread cache keys when using `Redis#mget`

### DIFF
--- a/lib/flipper/adapters/redis_cache.rb
+++ b/lib/flipper/adapters/redis_cache.rb
@@ -148,7 +148,7 @@ module Flipper
         return [] if keys.empty?
 
         cache_keys = keys.map { |key| key_for(key) }
-        @cache.mget(cache_keys).map do |value|
+        @cache.mget(*cache_keys).map do |value|
           value ? Marshal.load(value) : nil
         end
       end


### PR DESCRIPTION
The [signature of `Redis#mget` actually requires a splatted array of keys to fetch](https://www.rubydoc.info/gems/redis/3.1.0/Redis%3Amget). Currently, the implementation works fine for the default `redis` gem, but the current behavior (non-spreading) does not work with `redis-store`. This patch should fix that.